### PR TITLE
fix color of input text to black so its visible

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -163,7 +163,7 @@ const Header = (props: HeaderProps) => {
                 type="search"
                 ref={inputRef}
                 required
-                className="rounded-md border border-gray-300 px-2 py-1"
+                className="rounded-md border border-gray-300 px-2 py-1 text-black"
               />
               <i className="fa fa-search"></i>
               <button


### PR DESCRIPTION
# PR: Ensure Search Input Text is Readable

## Description

Updated the `Header` search input field to explicitly set `text-black` for readability as it seemed invisible before
## Changes

- **File:** `src/app/components/Header.tsx`
- **Modification:** 
 ```diff
 className="rounded-md border border-gray-300 px-2 py-1"
```
changed to:
```
className="rounded-md border border-gray-300 px-2 py-1 text-black"
```
## Why?
- Text had same color as bg before and therefore seemed invisible

## Checklist
- Tested locally.
- Maintains existing functionality.

