### PR TITLE
style: update KaTeX styles to support inline latex

### DIFF
--- a/src/app/[locale]/quantum_tuesdays/[difficulty]/[slug]/page.tsx
+++ b/src/app/[locale]/quantum_tuesdays/[difficulty]/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { getPostContent } from "@/app/components/server_utils";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { atomDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import wordsCounter from "word-counting";
+import "katex/dist/katex.min.css";
 
 export default function Post({
   params,
@@ -31,7 +32,9 @@ export default function Post({
       <article className="prose mx-auto block max-w-2xl px-6 text-black dark:text-white dark:prose-headings:text-white dark:prose-a:text-white dark:prose-strong:text-white dark:prose-code:bg-slate-500 dark:prose-code:text-white dark:prose-li:marker:text-white">
         <ReactMarkdown
           remarkPlugins={[remarkMath, remarkGfm]}
-          rehypePlugins={[rehypeKatex]} // need both remark and rehype plugins for proper latex rendering
+          rehypePlugins={[
+            [rehypeKatex, { throwOnError: false, strict: false }],
+          ]}
           components={{
             code({ node, className, children, ...props }) {
               const match = /language-(\w+)/.exec(className || "");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,8 +36,17 @@ body {
 }
 
 .katex {
+  display: inline-block;
+  text-align: left;
+  padding: 0;
+  margin: 0;
+}
+
+.katex-display {
   display: block;
-  padding-top: 2%;
-  padding-bottom: 2%;
   text-align: center;
+  padding: 1em 0;
+  margin: 1em 0;
+  overflow-x: auto;
+  overflow-y: hidden;
 }


### PR DESCRIPTION
# KaTeX Math Rendering Improvements

## Changes
- Added KaTeX CSS import to ensure proper styling of mathematical expressions
- Updated rehypeKatex configuration to handle math rendering errors gracefully
- Enhanced KaTeX styling in globals.css for better display of mathematical expressions

## Technical Details
- Added `throwOnError: false` and `strict: false` options to rehypeKatex to prevent rendering failures
- Improved CSS styling for both inline and display math:
  - Inline math (`.katex`) now has proper inline-block display and spacing
  - Display math (`.katex-display`) has improved block layout with proper margins and overflow handling
  - Added horizontal scroll for overflow content while preventing vertical scroll

## Testing
Please verify:
- Mathematical expressions render correctly in both inline and display modes
- Long mathematical expressions handle overflow appropriately
- No rendering errors occur with complex LaTeX expressions

## Related
- Fixes issues with LaTeX math rendering
- Improves mathematical content display across the site