### PR TITLE
Fix/footer scrolling

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,12 +3,11 @@ import type { Metadata } from "next";
 import "../globals.css";
 import "katex/dist/katex.min.css";
 import { NextIntlClientProvider } from "next-intl";
-import Footer from "../components/Footer";
 import Header from "../components/Header";
+import Footer from "../components/Footer";
 import { getMessages } from "next-intl/server";
 import { CookiesProvider } from "next-client-cookies/server";
 import EasterEgg from "../components/EasterEgg";
-
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
@@ -61,7 +60,7 @@ export default async function LocaleLayout({
         <NextIntlClientProvider messages={messages}>
           <Header locale={locale} />
           <EasterEgg />
-          <div className="flex-grow bg-gray-50 pb-10 text-black dark:bg-gray-900 dark:text-gray-100">
+          <div className="flex-grow bg-gray-50 text-black">
             <CookiesProvider>
               {children}
               <Analytics />

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -279,6 +279,14 @@ export default function Home({ params }: HomeProps) {
           </div>
         </div>
       </section>
+
+      {/* 
+        IMPORTANT: This empty scroll-snap-section is required for Edge browser compatibility.
+        Edge has issues with scroll-snap when the last section doesn't have the scroll-snap-section class.
+        DO NOT DELETE this section - it ensures proper scroll behavior across all browsers.
+        The footer is handled by the layout component to avoid duplication.
+      */}
+      <section className="scroll-snap-section"></section>
     </div>
   );
 }

--- a/src/app/[locale]/posts/[subfolder]/[difficulty]/[slug]/page.tsx
+++ b/src/app/[locale]/posts/[subfolder]/[difficulty]/[slug]/page.tsx
@@ -28,7 +28,7 @@ export default function Post({
   const numberOfWords = wordsCounter(post.content).wordsCount;
   const readingTime = Math.ceil(numberOfWords / 200);
   return (
-    <div className="mt-28">
+    <div className="my-28">
       <div className="my-12 text-center">
         <h1 className="text-2xl text-slate-600">{post.data.title}</h1>
         <p className="mt-2 text-slate-400">{post.data.date}</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,17 +47,37 @@ body {
 html {
   scroll-snap-type: y mandatory;
   scroll-behavior: smooth;
+  /* Edge compatibility */
+  -ms-scroll-snap-type: y mandatory;
+  -webkit-scroll-behavior: smooth;
 }
 
 /* Enhanced scroll snap styles */
 .scroll-snap-container {
   scroll-behavior: smooth;
   scroll-snap-type: y mandatory;
+  /* Edge compatibility */
+  -ms-scroll-snap-type: y mandatory;
+  -webkit-scroll-behavior: smooth;
 }
 
 .scroll-snap-section {
   scroll-snap-align: start;
   scroll-snap-stop: always;
+  /* Edge compatibility */
+  -ms-scroll-snap-align: start;
+  -ms-scroll-snap-stop: always;
+}
+
+/* Fallback for browsers that don't support scroll snap */
+@supports not (scroll-snap-type: y mandatory) {
+  .scroll-snap-container {
+    scroll-behavior: smooth;
+  }
+
+  .scroll-snap-section {
+    min-height: 100vh;
+  }
 }
 
 /*


### PR DESCRIPTION
# 📦 Pull Request

## ＊Related Issue(s)

<!-- List the Issue(s) this PR addresses -->

Closes #88

## ＊Summary & Motivation

> Enhances cross-browser support by adding Edge-specific scroll-snap prefixes and fallback styles, inserts a required empty `scroll-snap-section` for Edge compatibility, and cleans up layout/post spacing.

## ＊What kind of change does this PR introduce?

<!-- Select **one** by keeping the ✅ and removing the others -->

* ⬜ Feature
* ✅ Bug Fix
* ⬜ Performance Improvement
* ⬜ Refactor
* ⬜ Documentation
* ⬜ Blogpost / Content
* ⬜ CI / Tooling / Chore
* ⬜ Test
* ⬜ Other (describe below)

## Screenshots / Screen Recordings

<!-- Drag-and-drop images, videos, or copy Loom links as needed. -->

mf github complains bout filesize



## Implementation Notes

* **Key files touched:**

  * `src/app/[locale]/layout.tsx`
  * `src/app/[locale]/page.tsx`
  * `src/app/[locale]/posts/[subfolder]/[difficulty]/[slug]/page.tsx`
  * `src/app/globals.css`
* **Breaking changes:** ⬜ Yes ／ ✅ No

## ＊Testing Instructions

1. `bun install`
2. `bun run lint`
3. `bun dev` and navigate to `http://localhost:3000`
4. Manually test scroll-snap behavior in Edge and other browsers.

### Checklist

* [ ] I ran `bun run lint` with no errors
* [ ] I updated documentation & translations where applicable
* [ ] Browser-tested on ⬜ Chrome ⬜ Firefox ⬜ Safari ⬜ Edge ⬜ Mobile
* [ ] Added/updated Storybook stories or MDX demos
* [ ] Accessibility checked (contrast, focus order, alt text)

## Post-Deployment

* [ ] No migrations / external tasks needed

## 🤩 How does this PR make you feel?

shi was simple but bro am I tired damn, i need myself a white monster 

<div><img src="https://media2.giphy.com/media/lJnAXeJO8tE7E37mxq/giphy.gif?cid=26b2ae1ff8mov888kh59pkuvgy5qbj9u1zjcwupdfl1g1rca&amp;ep=v1_gifs_search&amp;rid=giphy.gif&amp;ct=g" style="border:0;height:174px;width:300px"/>